### PR TITLE
Implement G60/G61 (pos store/restore) from Marlin2.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1711,6 +1711,14 @@
                               // Default behaviour is limited to Z axis only.
 #endif
 
+/** 
+ *  G60/G61 support
+ *
+ *  Set the number of position save slots.
+ *  Requires NUM_AXIS (typically 4 or 5) floats (4 bytes each) memory per slot.
+ */
+//#define SAVED_POSITIONS 16
+
 // Enable Marlin dev mode which adds some special commands
 //#define MARLIN_DEV_MODE
 


### PR DESCRIPTION

### Requirements

Marlin-1.1.x firmware (and a bit of unused memory).

### Description

Marlin-2 has the ability to store the current position with G60 and
return to it later with G61. Backport the feature to Marlin-1.1.x.

### Benefits

Storing a position, moving somewhere else and then being able to return
can be quite useful, e.g. when changing extruders and wanting to dump
some primed filament at some definted place.

Define STORED_POSITIONS (with the number of wanted slots) to enable
the feature.
