### PR TITLE
Avoid precompiler warning redefining Y_MIN/MAX_PIN.

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -624,6 +624,8 @@
 #endif
 
 #ifdef Y_STOP_PIN
+  #undef Y_MIN_PIN
+  #undef Y_MAX_PIN
   #if Y_HOME_DIR < 0
     #define Y_MIN_PIN Y_STOP_PIN
     #define Y_MAX_PIN -1


### PR DESCRIPTION
### Requirements

Marlin-1.1.x

### Description

Fix precompiler warning.

### Benefits

Less noise during compilation (so you might better spot real problems).