### PR TITLE
Enable automated extruder fan control.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -237,17 +237,17 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN -1
-#define E1_AUTO_FAN_PIN -1
+#define E0_AUTO_FAN_PIN 17
+#define E1_AUTO_FAN_PIN 17
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1
 #define E4_AUTO_FAN_PIN -1
 #define CHAMBER_AUTO_FAN_PIN -1
-#define EXTRUDER_AUTO_FAN_TEMPERATURE 50
+#define EXTRUDER_AUTO_FAN_TEMPERATURE 45
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-// Auto-Fan for bed
-//#define BED_AUTO_FAN_PIN   17
-//#define BED_AUTO_FAN_TEMPERATURE 42
+// Auto-Fan for bed (use extruder fans)
+#define BED_AUTO_FAN_PIN   17
+#define BED_AUTO_FAN_TEMPERATURE 42
 
 
 /**

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -25,4 +25,4 @@ and at least reasonably close for the Bukito.
 * SD support
 * EEPROM support
 * S-Curve smoothing, Adaptive smoothing (multi-axis moves), diagonal homing (XY)
-
+* Extruder fans (pin17) run when extruders or bed are warm


### PR DESCRIPTION
### Requirements

* Marlin-1.1.x
* For the bed triggering the fans, you need the appropriate PR of mine merged

### Description

We switch the fans on (pin 17) when the extruders are above 45C
OR the bed is above 42C. (The latter is just a warning that the
bed has not cooled down yet -- the extruder fans do not help
significantly to cool down the bed obviously.)

### Benefits

The extruder fans only run when needed.
The triggering by the warm bed also provides a signal to the user.
