### PR TITLE
Put measured PID values into firmware as defaults.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration.h
+++ b/Marlin/example_configurations/Buko/Configuration.h
@@ -399,14 +399,14 @@
 #define MAX_REDUNDANT_TEMP_SENSOR_DIFF 10
 
 // Extruder temperature must be close to target for this long before M109 returns success
-#define TEMP_RESIDENCY_TIME 10  // (seconds)
-#define TEMP_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
-#define TEMP_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
+#define TEMP_RESIDENCY_TIME 8   // (seconds)
+#define TEMP_HYSTERESIS 4       // (degC) range of +/- temperatures considered "close" to the target one
+#define TEMP_WINDOW     2       // (degC) Window around target to start the residency timer x degC early.
 
 // Bed temperature must be close to target for this long before M190 returns success
-#define TEMP_BED_RESIDENCY_TIME 10  // (seconds)
-#define TEMP_BED_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
-#define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
+#define TEMP_BED_RESIDENCY_TIME 8   // (seconds)
+#define TEMP_BED_HYSTERESIS 4       // (degC) range of +/- temperatures considered "close" to the target one
+#define TEMP_BED_WINDOW     2       // (degC) Window around target to start the residency timer x degC early.
 
 // The minimal temperature defines the temperature below which the heater will not be enabled It is used
 // to check that the wiring to the thermistor is not broken.
@@ -445,15 +445,15 @@
   //#define SLOW_PWM_HEATERS // PWM with very low frequency (roughly 0.125Hz=8s) and minimum state time of approximately 1s useful for heaters driven by a relay
   //#define PID_PARAMS_PER_HOTEND // Uses separate PID parameters for each extruder (useful for mismatched extruders)
                                   // Set/get with gcode: M301 E[extruder number, 0-2]
-  #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
+  #define PID_FUNCTIONAL_RANGE 15 // If the temperature difference between the target temperature and the actual temperature
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
 
   // If you are using a pre-configured hotend then you can use one of the value sets by uncommenting it
 
   // Ultimaker
-  #define DEFAULT_Kp 22.2
-  #define DEFAULT_Ki 1.08
-  #define DEFAULT_Kd 114
+  //#define DEFAULT_Kp 22.2
+  //#define DEFAULT_Ki 1.08
+  //#define DEFAULT_Kd 114
 
   // MakerGear
   //#define DEFAULT_Kp 7.0
@@ -465,6 +465,20 @@
   //#define DEFAULT_Ki 2.25
   //#define DEFAULT_Kd 440
 
+#ifdef SPITFIRE
+// Spitfire
+    //#define  DEFAULT_Kp 8.29
+    //#define  DEFAULT_Ki 0.37
+    //#define  DEFAULT_Kd 45.91
+    // Measured KG 2020-04-22:
+    #define  DEFAULT_Kp 24.5
+    #define  DEFAULT_Ki 2.1
+    #define  DEFAULT_Kd 71.0
+#else
+// Bukoschnozzle
+    #define  DEFAULT_Kp 87.89
+    #define  DEFAULT_Ki 3.88
+    #define  DEFAULT_Kd 664.28
 #endif // PIDTEMP
 
 //===========================================================================
@@ -484,7 +498,7 @@
  * heater. If your configuration is significantly different than this and you don't understand
  * the issues involved, don't use bed PID until someone else verifies that your hardware works.
  */
-//#define PIDTEMPBED
+#define PIDTEMPBED
 
 //#define BED_LIMIT_SWITCHING
 
@@ -500,11 +514,16 @@
 
   //#define PID_BED_DEBUG // Sends debug data to the serial port.
 
+  // Measured BukoV2Duo, KG 2020-04-20
+  #define DEFAULT_bedKp 420.0
+  #define DEFAULT_bedKi 65.0
+  #define DEFAULT_bedKd 670.0
+
   //120V 250W silicone heater into 4mm borosilicate (MendelMax 1.5+)
   //from FOPDT model - kp=.39 Tp=405 Tdead=66, Tc set to 79.2, aggressive factor of .15 (vs .1, 1, 10)
-  #define DEFAULT_bedKp 10.00
-  #define DEFAULT_bedKi .023
-  #define DEFAULT_bedKd 305.4
+  //#define DEFAULT_bedKp 10.00
+  //#define DEFAULT_bedKi .023
+  //#define DEFAULT_bedKd 305.4
 
   //120V 250W silicone heater into 4mm borosilicate (MendelMax 1.5+)
   //from pidautotune
@@ -525,7 +544,7 @@
  * *** IT IS HIGHLY RECOMMENDED TO LEAVE THIS OPTION ENABLED! ***
  */
 #define PREVENT_COLD_EXTRUSION
-#define EXTRUDE_MINTEMP 170
+#define EXTRUDE_MINTEMP 160
 
 /**
  * Prevent a single extrusion longer than EXTRUDE_MAXLENGTH.

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -26,3 +26,4 @@ and at least reasonably close for the Bukito.
 * EEPROM support
 * S-Curve smoothing, Adaptive smoothing (multi-axis moves), diagonal homing (XY)
 * Extruder fans (pin17) run when extruders or bed are warm
+* Measured PID values for Bukov2Duo hotends (spitfire) and bed


### PR DESCRIPTION
### Requirements

Marlin-1.1.x
Bukobot with spitfire extruder  (PID params match it)

### Description

Use measured PID values (from Buko2Duo hotends and bed) as firmware defaults 
Also enable PID for bed.
Wait a bit less for temp convergence -- in my experience, being 3C off
is better than waiting for more filament to ooze out of the hotend ...

### Benefits

Faster temperature convergence, especially helpful when using multiple extruders.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
