### PR TITLE
Allow FWRETRACT to be used.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -1010,18 +1010,18 @@
  * Note that M207 / M208 / M209 settings are saved to EEPROM.
  *
  */
-//#define FWRETRACT  // ONLY PARTIALLY TESTED
+#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
-  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
-  #define RETRACT_LENGTH 3                // Default retract length (positive mm)
-  #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
-  #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)
-  #define RETRACT_ZLIFT 0                 // Default retract Z-lift
-  #define RETRACT_RECOVER_LENGTH 0        // Default additional recover length (mm, added to retract length when recovering)
-  #define RETRACT_RECOVER_LENGTH_SWAP 0   // Default additional swap recover length (mm, added to retract length when recovering from extruder change)
-  #define RETRACT_RECOVER_FEEDRATE 8      // Default feedrate for recovering from retraction (mm/s)
-  #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // Default feedrate for recovering from swap retraction (mm/s)
+  #define MIN_AUTORETRACT 0.2             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 12.0            // Upper limit for auto-retract conversion
+  #define RETRACT_LENGTH 2                // Default retract length (positive mm)
+  #define RETRACT_LENGTH_SWAP 12          // Default swap retract length (positive mm), for extruder change
+  #define RETRACT_FEEDRATE 20             // Default feedrate for retracting (mm/s)
+  #define RETRACT_ZLIFT 0.3               // Default retract Z-lift
+  #define RETRACT_RECOVER_LENGTH 0.05     // Default additional recover length (mm, added to retract length when recovering)
+  #define RETRACT_RECOVER_LENGTH_SWAP 4   // Default additional swap recover length (mm, added to retract length when recovering from extruder change)
+  #define RETRACT_RECOVER_FEEDRATE 4      // Default feedrate for recovering from retraction (mm/s)
+  #define RETRACT_RECOVER_FEEDRATE_SWAP 5 // Default feedrate for recovering from swap retraction (mm/s)
 #endif
 
 /**

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -27,3 +27,5 @@ and at least reasonably close for the Bukito.
 * S-Curve smoothing, Adaptive smoothing (multi-axis moves), diagonal homing (XY)
 * Extruder fans (pin17) run when extruders or bed are warm
 * Measured PID values for Bukov2Duo hotends (spitfire) and bed
+* FWRETRACT (G10/G11), use M209 S0 to not do it without being requested
+


### PR DESCRIPTION

### Requirements

* Marlin-1.1.x

### Description

Support G10/G11 as well as magic retract autodetection (if M209 S1 is enabled, which I do not suggest).

### Benefits

Cura and slic3r can emit G10/G11 codes, which become useful with this
firmware now. I suggest to keep the magic off by default with M209 S0.

