### PR TITLE
Acutally enable G60/G61 position store/restore.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -1719,7 +1719,7 @@
  *  Set the number of position save slots.
  *  Requires NUM_AXIS (typically 4 or 5) floats (4 bytes each) memory per slot.
  */
-//#define SAVED_POSITIONS 16
+#define SAVED_POSITIONS 16
 
 // Enable Marlin dev mode which adds some special commands
 //#define MARLIN_DEV_MODE

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -28,4 +28,4 @@ and at least reasonably close for the Bukito.
 * Extruder fans (pin17) run when extruders or bed are warm
 * Measured PID values for Bukov2Duo hotends (spitfire) and bed
 * FWRETRACT (G10/G11), use M209 S0 to not do it without being requested
-
+* Position storing (G60/G61) backported from Marlin-2.0.x


### PR DESCRIPTION
### Requirements

* Marlin-1.1.x Buko
* PR#2

### Description

Actually enable G60/G61 position store/restore.

### Benefits

This can be rather useful in a multi-extruder setup on tool change.

### Related Issues

Needs the backport from Marlin-2.0.x (PR #2)
