### PR TITLE
Enable manual probing with G29.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration.h
+++ b/Marlin/example_configurations/Buko/Configuration.h
@@ -1310,11 +1310,11 @@
  */
 #if ENABLED(AUTO_BED_LEVELING_3POINT) || ENABLED(AUTO_BED_LEVELING_UBL)
   //#define PROBE_PT_1_X 15
-  //#define PROBE_PT_1_Y 180
-  //#define PROBE_PT_2_X 15
-  //#define PROBE_PT_2_Y 20
-  //#define PROBE_PT_3_X 170
-  //#define PROBE_PT_3_Y 20
+  //#define PROBE_PT_1_Y 100
+  //#define PROBE_PT_2_X 190
+  //#define PROBE_PT_2_Y 15
+  //#define PROBE_PT_3_X 190
+  //#define PROBE_PT_3_Y 190
 #endif
 
 /**

--- a/Marlin/example_configurations/Buko/Configuration.h
+++ b/Marlin/example_configurations/Buko/Configuration.h
@@ -917,8 +917,8 @@
  * Use G29 repeatedly, adjusting the Z height at each point with movement commands
  * or (with LCD_BED_LEVELING) the LCD controller.
  */
-//#define PROBE_MANUALLY
-//#define MANUAL_PROBE_START_Z 0.2
+#define PROBE_MANUALLY
+#define MANUAL_PROBE_START_Z 0.2
 
 /**
  * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
@@ -981,15 +981,15 @@
  *      O-- FRONT --+
  *    (0,0)
  */
-#define X_PROBE_OFFSET_FROM_EXTRUDER 10  // X offset: -left  +right  [of the nozzle]
-#define Y_PROBE_OFFSET_FROM_EXTRUDER 10  // Y offset: -front +behind [the nozzle]
-#define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
+#define X_PROBE_OFFSET_FROM_EXTRUDER -15  // X offset: -left  +right  [of the nozzle]
+#define Y_PROBE_OFFSET_FROM_EXTRUDER -10  // Y offset: -front +behind [the nozzle]
+#define Z_PROBE_OFFSET_FROM_EXTRUDER 0    // Z offset: -below +above  [the nozzle]
 
 // Certain types of probes need to stay away from edges
 #define MIN_PROBE_EDGE 10
 
-// X and Y axis travel speed (mm/m) between probes
-#define XY_PROBE_SPEED 8000
+// X and Y axis travel speed (mm/min) between probes
+#define XY_PROBE_SPEED 6000
 
 // Feedrate (mm/m) for the first approach when double-probing (MULTIPLE_PROBING == 2)
 #define Z_PROBE_SPEED_FAST HOMING_FEEDRATE_Z

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -29,3 +29,5 @@ and at least reasonably close for the Bukito.
 * Measured PID values for Bukov2Duo hotends (spitfire) and bed
 * FWRETRACT (G10/G11), use M209 S0 to not do it without being requested
 * Position storing (G60/G61) backported from Marlin-2.0.x
+* Manual Probing with G29
+


### PR DESCRIPTION

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Support G29 for manual probing (without a z probe).

(Also, not enabled: Where would a probe be located on a BukoDuo extruder ....)

### Benefits

Make bed leveling a bit less painful.

### Related Issues
