### PR TITLE
Avoid raising z when homing if z is unknown.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration.h
+++ b/Marlin/example_configurations/Buko/Configuration.h
@@ -1077,7 +1077,7 @@
 
 //#define NO_MOTION_BEFORE_HOMING  // Inhibit movement until all axes have been homed
 
-//#define UNKNOWN_Z_NO_RAISE // Don't raise Z (lower the bed) if Z is "unknown." For beds that fall when Z is powered off.
+#define UNKNOWN_Z_NO_RAISE // Don't raise Z (lower the bed) if Z is "unknown." Avoid leaving the allowable range if we were already at the top.
 
 //#define Z_HOMING_HEIGHT 4  // (in mm) Minimal z height before homing (G28) for Z clearance above the bed, clamps, ...
                              // Be sure you have this distance over your Z_MAX_POS in case.


### PR DESCRIPTION
### Requirements

* Marlin-1.1.x

### Description

Avoid raising z if position is unknown.

### Benefits

Avoid risk of bumping again head of frame on G28 X1 Y1 (with unknown z and it being at the top already).