### PR TITLE
Enable emergency parser.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -953,14 +953,16 @@
 // For ADVANCED_OK (M105) you need 32 bytes.
 // For debug-echo: 128 bytes for the optimal speed.
 // Other output doesn't need to be that speedy.
+// Default: 32
 // :[0, 2, 4, 8, 16, 32, 64, 128, 256]
-#define TX_BUFFER_SIZE 0
+//#define TX_BUFFER_SIZE 32
 
 // Host Receive Buffer Size
 // Without XON/XOFF flow control (see SERIAL_XON_XOFF below) 32 bytes should be enough.
 // To use flow control, set this buffer size to at least 1024 bytes.
+// Default: 128
 // :[0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
-//#define RX_BUFFER_SIZE 1024
+//#define RX_BUFFER_SIZE 128
 
 #if RX_BUFFER_SIZE >= 1024
   // Enable to have the controller send XON/XOFF control characters to
@@ -982,7 +984,7 @@
 // enter the serial receive buffer, so they cannot be blocked.
 // Currently handles M108, M112, M410
 // Does not work on boards using AT90USB (USBCON) processors!
-//#define EMERGENCY_PARSER
+#define EMERGENCY_PARSER
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -30,4 +30,4 @@ and at least reasonably close for the Bukito.
 * FWRETRACT (G10/G11), use M209 S0 to not do it without being requested
 * Position storing (G60/G61) backported from Marlin-2.0.x
 * Manual Probing with G29
-
+* Emergency parser (software emergency abort)


### PR DESCRIPTION
### Requirements

* Marlin-1.1.x

### Description

Enable emergency parser.

### Benefits

If the software sends a serial command to stop, it is processed immediately.
So a kill will interrupt the current operation (which might be long-running).
