### PR TITLE
Enable Bezier curves and increase Arc resolution.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -862,14 +862,14 @@
 //
 #define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
-  #define MM_PER_ARC_SEGMENT  1   // Length of each arc segment
+  #define MM_PER_ARC_SEGMENT  0.5 // Length of each arc segment
   #define N_ARC_CORRECTION   25   // Number of intertpolated segments between corrections
-  //#define ARC_P_CIRCLES         // Enable the 'P' parameter to specify complete circles
+  #define ARC_P_CIRCLES           // Enable the 'P' parameter to specify complete circles
   //#define CNC_WORKSPACE_PLANES  // Allow G2/G3 to operate in XY, ZX, or YZ planes
 #endif
 
 // Support for G5 with XYZE destination and IJPQ offsets. Requires ~2666 bytes.
-//#define BEZIER_CURVE_SUPPORT
+#define BEZIER_CURVE_SUPPORT
 
 // G38.2 and G38.3 Probe Target
 // Set MULTIPLE_PROBING if you want G38 to double touch

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -31,3 +31,4 @@ and at least reasonably close for the Bukito.
 * Position storing (G60/G61) backported from Marlin-2.0.x
 * Manual Probing with G29
 * Emergency parser (software emergency abort)
+* Bezier curves (G5), well resolved Arcs (G2/G3, incl. full circles)


### PR DESCRIPTION
Bezier requires a bit of program code, which we have plenty of on
ATmega2560.
Also, allow full circles for Arcs and double the resolution (at the
expense of a bit more computation).

### Requirements

* Marlin-1.1.x with enough program capacity.

### Description

* Enable Bézier Curves (G5)
* Enable full circles on Arcs (G2/G3) and double resolution

### Benefits

This should support with creating smoother round shapes if used by the slicer.

### Related Issues

Typically slicers don't make use of G2/G3 nor G5, so you may have little benefit from enabling this.
So only use if you have plenty of program space ...
