### PR TITLE
More verbose M114 and SD status report.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -134,7 +134,7 @@
 #endif
 
 // Show extra position information in M114
-//#define M114_DETAIL
+#define M114_DETAIL
 
 // Show Temperature ADC value
 // Enable for M105 to include ADC values read from temperature sensors.
@@ -703,7 +703,7 @@
   #endif
 
   // This allows hosts to request long names for files and folders with M33
-  //#define LONG_FILENAME_HOST_SUPPORT
+  #define LONG_FILENAME_HOST_SUPPORT
 
   // Enable this option to scroll long filenames in the SD card menu
   //#define SCROLL_LONG_FILENAMES
@@ -725,7 +725,7 @@
   /**
    * Auto-report SdCard status with M27 S<seconds>
    */
-  //#define AUTO_REPORT_SD_STATUS
+  #define AUTO_REPORT_SD_STATUS
 
 #endif // SDSUPPORT
 
@@ -841,7 +841,7 @@
  */
 //#define LIN_ADVANCE
 #if ENABLED(LIN_ADVANCE)
-  #define LIN_ADVANCE_K 0.22  // Unit: mm compression per 1mm/s extruder speed
+  #define LIN_ADVANCE_K 0.06  // Unit: mm compression per 1mm/s extruder speed
   //#define LA_DEBUG          // If enabled, this will generate debug information output over USB.
 #endif
 

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -22,7 +22,7 @@ and at least reasonably close for the Bukito.
 
 # Enabled features
 
-* SD support
+* SD support (incl. long file names)
 * EEPROM support
 * S-Curve smoothing, Adaptive smoothing (multi-axis moves), diagonal homing (XY)
 * Extruder fans (pin17) run when extruders or bed are warm
@@ -32,3 +32,4 @@ and at least reasonably close for the Bukito.
 * Manual Probing with G29
 * Emergency parser (software emergency abort)
 * Bezier curves (G5), well resolved Arcs (G2/G3, incl. full circles)
+* More verbose M114 and SD status reporting


### PR DESCRIPTION
Also enable long filenames for SD card.

### Requirements

* Marlin-1.1.x

### Description

Enable some more reporting for Marlin:
* More details from M114
* Support long SD file names (M33) and regular SD status reports (M27)

### Benefits

More user-friendliness.

