### PR TITLE
More serial buffering and advanced OK.

### DIFF
--- a/Marlin/example_configurations/Buko/Configuration_adv.h
+++ b/Marlin/example_configurations/Buko/Configuration_adv.h
@@ -936,16 +936,16 @@
 // The number of linear motions that can be in the plan at any give time.
 // THE BLOCK_BUFFER_SIZE NEEDS TO BE A POWER OF 2 (e.g. 8, 16, 32) because shifts and ors are used to do the ring-buffering.
 #if ENABLED(SDSUPPORT)
-  #define BLOCK_BUFFER_SIZE 16 // SD,LCD,Buttons take more memory, block buffer needs to be smaller
+  #define BLOCK_BUFFER_SIZE 32 // SD,LCD,Buttons take more memory, block buffer needs to be smaller
 #else
-  #define BLOCK_BUFFER_SIZE 16 // maximize block buffer
+  #define BLOCK_BUFFER_SIZE 64 // maximize block buffer
 #endif
 
 // @section serial
 
 // The ASCII buffer for serial input
 #define MAX_CMD_SIZE 96
-#define BUFSIZE 4
+#define BUFSIZE 32
 
 // Transmission to Host Buffer Size
 // To save 386 bytes of PROGMEM (and TX_BUFFER_SIZE+3 bytes of RAM) set to 0.
@@ -962,7 +962,7 @@
 // To use flow control, set this buffer size to at least 1024 bytes.
 // Default: 128
 // :[0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
-//#define RX_BUFFER_SIZE 128
+#define RX_BUFFER_SIZE 2048
 
 #if RX_BUFFER_SIZE >= 1024
   // Enable to have the controller send XON/XOFF control characters to
@@ -993,7 +993,7 @@
 //#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-//#define ADVANCED_OK
+#define ADVANCED_OK
 
 // @section extras
 

--- a/Marlin/example_configurations/Buko/README.md
+++ b/Marlin/example_configurations/Buko/README.md
@@ -33,3 +33,4 @@ and at least reasonably close for the Bukito.
 * Emergency parser (software emergency abort)
 * Bezier curves (G5), well resolved Arcs (G2/G3, incl. full circles)
 * More verbose M114 and SD status reporting
+* Large serial buffers and advanced OK for a slight increase in serial performance


### PR DESCRIPTION
### Requirements

* Marlin-1.1x
* Enough RAM for some serial buffering

### Description

This provides larger serial buffers and an advanced OK that supports Octoprint or other clients to understand when more data can be sent without blocking.

### Benefits

Somewhat better serial performance, may be important for print speed of highly resolved small models.

### Related Issues

See https://github.com/OctoPrint/OctoPrint/issues/2834.